### PR TITLE
🌔 달이 차오른다, 가자.

### DIFF
--- a/[BOJ]1194.java
+++ b/[BOJ]1194.java
@@ -1,0 +1,91 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+class Info {
+	int x;
+	int y;
+	int bitmask;
+	int moveCount;
+
+	public Info(int x, int y, int bitmask, int moveCount) {
+		this.x = x;
+		this.y = y;
+		this.bitmask = bitmask;
+		this.moveCount = moveCount;
+	}
+}
+
+public class Main {
+	static int N, M;
+	static char[][] maze;
+	static boolean[][][] visited;
+	static int[][] direction = {{0, 1}, {-1, 0}, {1, 0}, {0, -1}};
+	
+	static int bfs(Info info) {
+		visited[info.x][info.y][0] = true;
+		Queue<Info> queue = new LinkedList<>();
+		queue.add(info);
+		while (!queue.isEmpty()) {
+			Info top = queue.poll();
+			visited[top.x][top.y][top.bitmask] = true;
+			if (maze[top.x][top.y] == '1') return top.moveCount;
+			for (int i = 0; i < 4; i++) {
+				int newX = top.x + direction[i][0];
+				int newY = top.y + direction[i][1];
+				if (newX >= 0 && newY >= 0 && newX < N && newY < M) {
+					if (!visited[newX][newY][top.bitmask]) {
+						switch(maze[newX][newY]) {
+						case '1':
+							return top.moveCount + 1;
+						case '0':
+						case '.':
+							visited[newX][newY][top.bitmask] = true;
+							queue.add(new Info(newX, newY, top.bitmask, top.moveCount + 1)); // break 안해도 아래서 걸림
+						case '#':
+							break;
+						case 'a':
+						case 'b':
+						case 'c':
+						case 'd':
+						case 'e':
+						case 'f':
+							visited[newX][newY][top.bitmask] = true;
+							queue.add(new Info(newX, newY, top.bitmask | 1 << 'f' - maze[newX][newY], top.moveCount + 1));
+							break;
+						case 'A':
+						case 'B':
+						case 'C':
+						case 'D':
+						case 'E':
+						case 'F':
+							visited[newX][newY][top.bitmask] = true;
+							// 맞는 열쇠가 없다ㅠㅠ
+							if (((top.bitmask) & (1 << 'F' - maze[newX][newY])) == 0) break;
+							// 맞는 열쇠가 있다ㅎㅎ
+							else queue.add(new Info(newX, newY, top.bitmask, top.moveCount + 1));
+						}
+					}
+				}
+			}
+		}
+		return -1;
+	}
+	
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		maze = new char[N][M];
+		visited = new boolean[N][M][64];
+		for (int i = 0; i < N; i++) maze[i] = br.readLine().toCharArray();
+		for (int i = 0; i < N; i++) {
+			for (int j = 0; j < M; j++) {
+				if (maze[i][j] == '0') System.out.println(bfs(new Info(i, j, 0, 0)));
+			}
+		}
+	}
+}


### PR DESCRIPTION
🌔 달이 차오른다, 가즈아~

## 후기
**32개 미만의 열쇠와 문이 있다는 것을 보고 비트마스킹을 사용**했다! (문제에선 6개다.)
근데 정작 중요한 것은, 열쇠를 주운 경우 왔던 길을 다시 돌아가야 하는 경우가 있다.
그렇다면, 열쇠를 먹은 시점에서 `visited` 배열을 초기화해야 하나? 하는 의문점이 들었다.
지나온 길은 `visited` 배열에서 `true`이기 때문에 열쇠를 먹은 순간 왔던 길로 되돌아갈 수 없기 때문이다.

그래서 막무가내로, 열쇠를 먹으면 `visited` 배열을 초기화하고 열쇠가 있던 자리만 `visited` 배열의 값을 `true`로 바꾸는 방법을 사용했다.
하지만 결과는 당연하게도 실패였다. 이유는 다음과 같다.
1. BFS를 Queue를 사용해서 구현했는데, 다른 열쇠를 먹으러 가는 길인 경우가 Queue의 앞에 위치해서 내가 돌아가야 할 길의 `visited` 값을 `true`로 만들어버리는 경우가 있다.
2. 열쇠가 2개 이상일 경우 서로 다른 열쇠를 먹을 때마다 `visited` 배열이 초기화되어 정상적인 너비 우선 탐색이 불가능해진다.
위에서 언급한 문제 말고도 여러 문제가 발생했기 때문에 이 아이디어는 폐기되었다.

해결 방안을 찾지 못하여 구글링을 살짝 해봤다. 그리고 엄청나게 획기적인 아이디어를 알게 되었다.
> **각 비트마스킹 경우마다 `visited` 배열을 따로 두면 된다.**

이렇게 할 경우 열쇠를 먹을 때마다 `visited` 배열을 초기화하면서도, 각 비트마스킹 경우마다 서로 다른 `visited` 배열을 가지게 되므로 위에서 언급한 문제가 전부 해결된다.
다만 정말 64개(2<sup>6</sup>. 문제에서 가능한 모든 비트마스킹 경우의 수)의 `N * M` 크기의 `visited` 배열을 만들 필요는 없고, `visited` 배열을 3차원 배열로 만들어서 마지막 index는 각 비트마스킹의 경우로 사용하면 된다.

## 결론
이 문제의 핵심을 두 줄로 요약하면 다음과 같다!
**1. 비트마스킹을 사용한다.**
**2. `visited` 배열을 3차원 배열로 사용한다.**