### PR TITLE
📘 선수과목

### DIFF
--- a/[BOJ]14567.java
+++ b/[BOJ]14567.java
@@ -1,0 +1,35 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+	static boolean[][] pre;
+	static int[] answer;
+	
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		int N = Integer.parseInt(st.nextToken());
+		pre = new boolean[N][N];
+		answer = new int[N];
+		int M = Integer.parseInt(st.nextToken());
+		for (int i = 0; i < M; i++) {
+			st = new StringTokenizer(br.readLine());
+			int prerequisite = Integer.parseInt(st.nextToken())-1;
+			int subject = Integer.parseInt(st.nextToken())-1;
+			pre[prerequisite][subject] = true;
+		}
+		for (int i = 0; i < N; i++) {
+			for (int j = 0; j < N; j++) {
+				if (pre[i][j]) answer[j] = Math.max(answer[j], answer[i]+1);
+			}
+		}
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < N; i++) {
+			sb.append(answer[i]+1).append(' ');
+		}
+		System.out.println(sb.toString());
+	}
+	
+}


### PR DESCRIPTION
📘 선수과목 리뷰해주세요~

## 풀이에 사용할 알고리즘 구상

알고리즘 분류를 보면 위상 정렬 문제지만 위상 정렬을 몰라도 풀 수 있다.

먼저, M개의 줄에 걸친 선수과목 조건의 입력이 무조건 오름차순이라는 보장은 없기 때문에 별도로 선수과목 정보를 담고 있는 이차원 배열 `pre`를 만들었다.

`pre[prerequisite][subject]`가 참이면, subject의 선수과목이 prerequisite라는 뜻이다.

M개의 줄에 걸친 선수과목 조건의 입력을 받으면서 이 배열에 true를 채워넣는다.

그 후, 정답(과목을 수강하는 데 소요되는 학기 수)을 담을 배열 `answer`에 대하여,

`pre[i][j]`가 참일 경우 `answer[j]`의 값을 `answer[i]+1`와 `answer[j]` 중 더 큰 값으로 갱신하면 된다.

왜냐하면, i를 수강할 때까지 든 학기 수보다 학기 수가 1만큼 더 필요하기 때문에 `answer[i]+1`로 갱신을 하는 것이다. 그런데, `answer[j]`가 이미 다른 선수과목에 의해 더 큰 값으로 설정되어 있을 가능성이 있기 때문에 `answer[j]`와도 비교하여 더 큰 값으로 갱신하는 것이다.

이렇게 `answer` 배열 전체에 대하여 갱신 과정이 끝나면, 이 배열에 담긴 값을 출력하면 끝.